### PR TITLE
Account for branch name being path structure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -116,7 +116,7 @@ runs:
         Write-Verbose "Starting directory: $pwd"
         $modulepath = "${{ inputs.module-path }}"
         $usertemp = [System.IO.Path]::GetTempPath()
-        $tempzip = Join-Path -Path $usertemp -ChildPath "branch$branch.zip"
+        $tempzip = Join-Path -Path $usertemp -ChildPath (Join-Path -Path "branch" -ChildPath "$branch.zip")
 
         # The directory where the module will be extracted to, cleaned then zipped
         $finalmoduledir = Join-Path -Path $usertemp -ChildPath $modulename


### PR DESCRIPTION
Git allows for path structure when creating branch names (e.g., `smelton/mybranch`)

Update handles that pattern.